### PR TITLE
Fix for source_type === 'global' on some multisites. 

### DIFF
--- a/src/Fieldtypes/FieldItemRelationshipFieldtype.php
+++ b/src/Fieldtypes/FieldItemRelationshipFieldtype.php
@@ -53,8 +53,13 @@ class FieldItemRelationshipFieldtype extends Fieldtype
                     'error_message' => "Global set \"{$this->config('source_global_set')}\" not found.",
                 ];
             }
-
-            $sourceValue = $global->inCurrentSite()->get($this->config('source_field'));
+            
+            $site = request()->query('site');
+            if ($site) {
+              $sourceValue = $global->in($site)->get($this->config('source_field'));
+            } else {
+              $sourceValue = $global->inCurrentSite()->get($this->config('source_field'));
+            }
 
             if (!$sourceValue) {
                 return [

--- a/src/Fieldtypes/FieldItemRelationshipFieldtype.php
+++ b/src/Fieldtypes/FieldItemRelationshipFieldtype.php
@@ -55,6 +55,9 @@ class FieldItemRelationshipFieldtype extends Fieldtype
             }
             
             $site = request()->query('site');
+
+            $site = $this->field?->parent()?->locale() ?? $site;
+            
             if ($site) {
               $sourceValue = $global->in($site)->get($this->config('source_field'));
             } else {


### PR DESCRIPTION
Retrieving the data using the URL query parameter that Statamic automatically sets in the URL (e.g http:/some-website.test/cp/globals/theme?site=another_site) is more reliable on multisites that have sites configured on the same domain. This was an issue on my local development environment. The original code only works if the multisites are hosted on different domains. Fallback to the original code is provided.